### PR TITLE
商品登録時に初期在庫数(initialStock)を省略すると500エラーになる不具合の修正

### DIFF
--- a/src/main/java/com/springmart/service/ProductService.java
+++ b/src/main/java/com/springmart/service/ProductService.java
@@ -45,7 +45,8 @@ public class ProductService {
         // 在庫テーブルに初期在庫数を登録
         Inventory inventory = new Inventory();
         inventory.setProduct(product);
-        inventory.setStockQuantity(request.getInitialStock());
+        int initialStock = request.getInitialStock() != null ? request.getInitialStock() : 0;
+        inventory.setStockQuantity(initialStock);
         inventoryRepository.save(inventory);
 
         return new ProductResponse(product.getId(), product.getName(), product.getDescription(), product.getPrice());


### PR DESCRIPTION
## 概要
新規商品登録用のAPI (`POST /api/products`) において、リクエストボディ内の `initialStock`（初期在庫数）が省略された場合、NullPointerExceptionが発生し500エラーとなる不具合を修正しました。

Closes #〇〇 <!-- 取組中のIssue番号があれば記載してください -->

## バグの原因
[ProductRequest](cci:2://file:///env/spring-mart/src/main/java/com/springmart/dto/ProductRequest.java:7:0-20:1) にて `initialStock` が `Integer` 型として定義されていますが、これが未指定（`null`）のまま送られてきている状態で、`inventory.setStockQuantity()`（プリミティブの `int` を要求する）に渡される過程でアンボクシングが行われ、`NullPointerException` が発生していました。

## 変更内容
- [ProductService.java](cci:7://file:///env/spring-mart/src/main/java/com/springmart/service/ProductService.java:0:0-0:0) の [createProduct](cci:1://file:///env/spring-mart/src/main/java/com/springmart/service/ProductService.java:36:4-52:5) メソッドを修正しました。
- `request.getInitialStock()` の値が `null` であるか判定し、`null` の場合は自動的にデフォルト値として `0` （在庫ゼロ）を [Inventory](cci:2://file:///env/spring-mart/src/main/java/com/springmart/entity/Inventory.java:9:0-36:1) に登録するようフォールバック処理を追加しました。

## 動作確認手順
以下の手順にて、NPEが発生せずに正常に商品が登録されることを確認しました。

1. **トークンの取得**
   - `admin` ユーザーとしてログインAPIを叩き、JWTトークンを取得。
2. **在庫省略パターンのテスト**
   - Headersにトークンをセットし、`POST /api/products` へ以下の内容を送信（`initialStock` の意図的な省略）。
     ```json
     {
         "name": "NPE修正テスト商品",
         "description": "初期在庫の指定なし",
         "price": 1000
     }
     ```
   - レスポンスとして正常終了が返り、データベース上で当該商品の在庫データが `stock_quantity = 0` として生成されていることを確認。
