### PR TITLE
JWTを用いたロールベースアクセス制御（RBAC）の実装

### DIFF
--- a/src/main/java/com/springmart/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/springmart/controller/GlobalExceptionHandler.java
@@ -24,6 +24,31 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
     
+    @ExceptionHandler(org.springframework.dao.CannotAcquireLockException.class)
+    public ResponseEntity<Map<String, String>> handleLockException(org.springframework.dao.CannotAcquireLockException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "注文の競合");
+        errorResponse.put("message", "現在アクセスが集中しており注文を完了できませんでした。恐れ入りますが、もう一度お試しください。");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
+    @ExceptionHandler(com.springmart.exception.ExpiredTokenException.class)
+    public ResponseEntity<Map<String, String>> handleExpiredTokenException(com.springmart.exception.ExpiredTokenException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "認証エラー");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+    @ExceptionHandler(com.springmart.exception.InvalidTokenException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidTokenException(com.springmart.exception.InvalidTokenException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "認証エラー");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException ex) {
         Map<String, String> errorResponse = new HashMap<>();

--- a/src/main/java/com/springmart/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/springmart/controller/GlobalExceptionHandler.java
@@ -48,6 +48,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
 
+    @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDeniedException(org.springframework.security.access.AccessDeniedException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "権限エラー");
+        errorResponse.put("message", "この操作を行う権限がありません。");
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+    }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException ex) {

--- a/src/main/java/com/springmart/exception/ExpiredTokenException.java
+++ b/src/main/java/com/springmart/exception/ExpiredTokenException.java
@@ -1,0 +1,7 @@
+package com.springmart.exception;
+
+public class ExpiredTokenException extends RuntimeException {
+    public ExpiredTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/springmart/exception/InvalidTokenException.java
+++ b/src/main/java/com/springmart/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.springmart.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/springmart/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/springmart/security/JwtAuthenticationFilter.java
@@ -18,31 +18,40 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     
     private final JwtTokenProvider jwtTokenProvider;
+    private final org.springframework.web.servlet.HandlerExceptionResolver resolver;
     
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, 
+                                   @org.springframework.beans.factory.annotation.Qualifier("handlerExceptionResolver") 
+                                   org.springframework.web.servlet.HandlerExceptionResolver resolver) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.resolver = resolver;
     }
     
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         
-        String token = getTokenFromRequest(request);
-        
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            String username = jwtTokenProvider.getUsernameFromToken(token);
-            String role = jwtTokenProvider.getRoleFromToken(token);
+        try {
+            String token = getTokenFromRequest(request);
             
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    username,
-                    null,
-                    Collections.singletonList(new SimpleGrantedAuthority(role))
-            );
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                String username = jwtTokenProvider.getUsernameFromToken(token);
+                String role = jwtTokenProvider.getRoleFromToken(token);
+                
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        username,
+                        null,
+                        Collections.singletonList(new SimpleGrantedAuthority(role))
+                );
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            // 例外が発生した場合はGlobalExceptionHandlerに処理を委譲する
+            resolver.resolveException(request, response, null, e);
         }
-        
-        filterChain.doFilter(request, response);
     }
     
     private String getTokenFromRequest(HttpServletRequest request) {

--- a/src/main/java/com/springmart/security/JwtTokenProvider.java
+++ b/src/main/java/com/springmart/security/JwtTokenProvider.java
@@ -63,8 +63,10 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token);
             return true;
-        } catch (Exception e) {
-            return false;
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            throw new com.springmart.exception.ExpiredTokenException("有効期限が切れています。再度ログインしてください。");
+        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
+            throw new com.springmart.exception.InvalidTokenException("無効なトークンです。再度ログインしてください。");
         }
     }
 }

--- a/src/main/java/com/springmart/security/SecurityConfig.java
+++ b/src/main/java/com/springmart/security/SecurityConfig.java
@@ -49,6 +49,11 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .exceptionHandling(exceptions -> exceptions
+                .accessDeniedHandler((request, response, accessDeniedException) -> {
+                    response.setStatus(403);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"error\":\"権限エラー\",\"message\":\"この操作を行う権限がありません。\"}");
+                })
                 .authenticationEntryPoint((request, response, authException) -> {
                     response.setStatus(401);
                     response.setContentType("application/json;charset=UTF-8");
@@ -59,6 +64,14 @@ public class SecurityConfig {
                 .requestMatchers("/", "/health").permitAll()
                 .requestMatchers("/auth/login").permitAll()
                 .requestMatchers("/dev/**").permitAll()
+                // 商品管理：登録・更新・削除は管理者の権限(ROLE_ADMIN)が必要
+                .requestMatchers(org.springframework.http.HttpMethod.POST, "/api/products/**").hasRole("ADMIN")
+                .requestMatchers(org.springframework.http.HttpMethod.PUT, "/api/products/**").hasRole("ADMIN")
+                .requestMatchers(org.springframework.http.HttpMethod.DELETE, "/api/products/**").hasRole("ADMIN")
+                // 商品管理：閲覧はログインユーザー全員が可能
+                .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/products/**").authenticated()
+                // 注文管理：ログインユーザー(JWTトークン保持者)のみ可能
+                .requestMatchers("/api/orders/**").authenticated()
                 .anyRequest().permitAll()
             )
             // 入場ゲートの入り口に案内係(JWTフィルター)を立たせる

--- a/src/main/java/com/springmart/security/SecurityConfig.java
+++ b/src/main/java/com/springmart/security/SecurityConfig.java
@@ -48,12 +48,21 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(401);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"error\":\"認証エラー\",\"message\":\"認証が必要です。\"}");
+                })
+            )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/health").permitAll()
                 .requestMatchers("/auth/login").permitAll()
                 .requestMatchers("/dev/**").permitAll()
                 .anyRequest().permitAll()
-            );
+            )
+            // 入場ゲートの入り口に案内係(JWTフィルター)を立たせる
+            .addFilterBefore(jwtAuthenticationFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
         
         return http.build();
     }

--- a/src/test/java/com/springmart/security/JwtSecurityTest.java
+++ b/src/test/java/com/springmart/security/JwtSecurityTest.java
@@ -1,0 +1,120 @@
+package com.springmart.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springmart.entity.User;
+import com.springmart.repository.UserRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class JwtSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    private String validAdminToken;
+    private String validUserToken;
+
+    @BeforeEach
+    void setUp() {
+        // Clear repository to prevent duplicate key issues during tests if any
+        userRepository.deleteAll();
+
+        // Create Admin User
+        User admin = new User();
+        admin.setUserName("adminUser");
+        admin.setPassword(passwordEncoder.encode("password"));
+        admin.setRole("ROLE_ADMIN");
+        userRepository.save(admin);
+
+        this.validAdminToken = jwtTokenProvider.generateToken(admin.getUserName(), admin.getRole());
+
+        User normalUser = new User();
+        normalUser.setUserName("generalUser");
+        normalUser.setPassword(passwordEncoder.encode("password"));
+        normalUser.setRole("ROLE_USER");
+        userRepository.save(normalUser);
+
+        this.validUserToken = jwtTokenProvider.generateToken(normalUser.getUserName(), normalUser.getRole());
+    }
+
+    @Test
+    void testAccessWithValidUserToken() throws Exception {
+        // Normal user should be able to access GET /api/products
+        mockMvc.perform(get("/api/products")
+                .header("Authorization", "Bearer " + validUserToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testAccessWithValidAdminToken() throws Exception {
+        // Admin user should be able to access GET /api/products
+        mockMvc.perform(get("/api/products")
+                .header("Authorization", "Bearer " + validAdminToken))
+                .andExpect(status().isOk());
+    }
+
+
+    @Test
+    void testInvalidTokenErrorHandling() throws Exception {
+        String invalidToken = "invalid.token.string.here";
+
+        // Accessing with invalid token -> Expected 401 Unauthorized
+        mockMvc.perform(get("/api/products")
+                .header("Authorization", "Bearer " + invalidToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("認証エラー"));
+    }
+
+    @Test
+    void testExpiredTokenErrorHandling() throws Exception {
+        // Intentionally create an expired token
+        SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+        
+        String expiredToken = Jwts.builder()
+                .subject("user@example.com")
+                .claim("role", "ROLE_USER")
+                .issuedAt(new Date(System.currentTimeMillis() - 1000 * 60 * 60 * 24)) // Issued 1 day ago
+                .expiration(new Date(System.currentTimeMillis() - 1000 * 60)) // Expired 1 min ago
+                .signWith(key)
+                .compact();
+
+        // Accessing with expired token -> Expected 401 Unauthorized
+        mockMvc.perform(get("/api/products")
+                .header("Authorization", "Bearer " + expiredToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("認証エラー"))
+                .andExpect(jsonPath("$.message").value("有効期限が切れています。再度ログインしてください。"));
+    }
+}

--- a/src/test/java/com/springmart/security/JwtSecurityTest.java
+++ b/src/test/java/com/springmart/security/JwtSecurityTest.java
@@ -85,6 +85,18 @@ public class JwtSecurityTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    void testRoleBasedAccessRestriction_UserAccessingAdminEndpoint() throws Exception {
+        String newProductJson = "{\"name\":\"Sample Product\",\"price\":1000,\"stockQuantity\":10,\"description\":\"Test\"}";
+
+        // Normal user trying to access POST /api/products (Requires ROLE_ADMIN) -> Expected 403 Forbidden
+        mockMvc.perform(post("/api/products")
+                .header("Authorization", "Bearer " + validUserToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(newProductJson))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").value("権限エラー"));
+    }
 
     @Test
     void testInvalidTokenErrorHandling() throws Exception {


### PR DESCRIPTION
## 概要
JWTを利用したロールベースアクセス制御の実装

## 変更内容
- `SecurityConfig` にてAPIごとにアクセス権限のルールを設定（例: 商品の追加・更新・削除は `ROLE_ADMIN` のみ可能、など）
- `GlobalExceptionHandler` およびセキュリティ設定の `accessDeniedHandler` について、権限不足時の例外(403 Forbidden)を処理するように追加
- 一般ユーザーが管理者用APIにアクセスしようとした際に弾かれるかを確認する統合テストを `JwtSecurityTest` に追加

## 影響範囲
- 商品・注文関連APIへのアクセス権（特に管理者のみアクセス可能なPOST/PUT/DELETE APIと、一般ユーザーのアクセス制御の部分）


## 確認事項
- [ ] 一般ユーザー(ROLE_USER)が商品作成・更新などの管理者専用APIにアクセスした場合、403(権限エラー)が返ること
- [ ] 管理者(ROLE_ADMIN)が問題なく商品管理API群へアクセスできること
- [ ] ログインしていないユーザーが認証を要するAPIへアクセスした場合、401(認証エラー)が返ること

## 補足
このように返るようになりました
`{
  "error": "認証エラー",
  "message": "有効期限が切れています。"
}`


