### PR TITLE
JWT認証エラーハンドリングの実装

### DIFF
--- a/src/main/java/com/springmart/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/springmart/controller/GlobalExceptionHandler.java
@@ -24,6 +24,31 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
     
+    @ExceptionHandler(org.springframework.dao.CannotAcquireLockException.class)
+    public ResponseEntity<Map<String, String>> handleLockException(org.springframework.dao.CannotAcquireLockException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "注文の競合");
+        errorResponse.put("message", "現在アクセスが集中しており注文を完了できませんでした。恐れ入りますが、もう一度お試しください。");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
+    @ExceptionHandler(com.springmart.exception.ExpiredTokenException.class)
+    public ResponseEntity<Map<String, String>> handleExpiredTokenException(com.springmart.exception.ExpiredTokenException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "認証エラー");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+    @ExceptionHandler(com.springmart.exception.InvalidTokenException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidTokenException(com.springmart.exception.InvalidTokenException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "認証エラー");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException ex) {
         Map<String, String> errorResponse = new HashMap<>();

--- a/src/main/java/com/springmart/exception/ExpiredTokenException.java
+++ b/src/main/java/com/springmart/exception/ExpiredTokenException.java
@@ -1,0 +1,7 @@
+package com.springmart.exception;
+
+public class ExpiredTokenException extends RuntimeException {
+    public ExpiredTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/springmart/exception/InvalidTokenException.java
+++ b/src/main/java/com/springmart/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.springmart.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/springmart/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/springmart/security/JwtAuthenticationFilter.java
@@ -18,31 +18,40 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     
     private final JwtTokenProvider jwtTokenProvider;
+    private final org.springframework.web.servlet.HandlerExceptionResolver resolver;
     
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, 
+                                   @org.springframework.beans.factory.annotation.Qualifier("handlerExceptionResolver") 
+                                   org.springframework.web.servlet.HandlerExceptionResolver resolver) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.resolver = resolver;
     }
     
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         
-        String token = getTokenFromRequest(request);
-        
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            String username = jwtTokenProvider.getUsernameFromToken(token);
-            String role = jwtTokenProvider.getRoleFromToken(token);
+        try {
+            String token = getTokenFromRequest(request);
             
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    username,
-                    null,
-                    Collections.singletonList(new SimpleGrantedAuthority(role))
-            );
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                String username = jwtTokenProvider.getUsernameFromToken(token);
+                String role = jwtTokenProvider.getRoleFromToken(token);
+                
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        username,
+                        null,
+                        Collections.singletonList(new SimpleGrantedAuthority(role))
+                );
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            // 例外が発生した場合はGlobalExceptionHandlerに処理を委譲する
+            resolver.resolveException(request, response, null, e);
         }
-        
-        filterChain.doFilter(request, response);
     }
     
     private String getTokenFromRequest(HttpServletRequest request) {

--- a/src/main/java/com/springmart/security/JwtTokenProvider.java
+++ b/src/main/java/com/springmart/security/JwtTokenProvider.java
@@ -63,8 +63,10 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token);
             return true;
-        } catch (Exception e) {
-            return false;
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            throw new com.springmart.exception.ExpiredTokenException("有効期限が切れています。再度ログインしてください。");
+        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
+            throw new com.springmart.exception.InvalidTokenException("無効なトークンです。再度ログインしてください。");
         }
     }
 }

--- a/src/main/java/com/springmart/security/SecurityConfig.java
+++ b/src/main/java/com/springmart/security/SecurityConfig.java
@@ -48,12 +48,21 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(401);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"error\":\"認証エラー\",\"message\":\"認証が必要です。\"}");
+                })
+            )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/health").permitAll()
                 .requestMatchers("/auth/login").permitAll()
                 .requestMatchers("/dev/**").permitAll()
                 .anyRequest().permitAll()
-            );
+            )
+            // 入場ゲートの入り口に案内係(JWTフィルター)を立たせる
+            .addFilterBefore(jwtAuthenticationFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
         
         return http.build();
     }

--- a/src/test/java/com/springmart/security/JwtSecurityTest.java
+++ b/src/test/java/com/springmart/security/JwtSecurityTest.java
@@ -1,0 +1,120 @@
+package com.springmart.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springmart.entity.User;
+import com.springmart.repository.UserRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class JwtSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    private String validAdminToken;
+    private String validUserToken;
+
+    @BeforeEach
+    void setUp() {
+        // Clear repository to prevent duplicate key issues during tests if any
+        userRepository.deleteAll();
+
+        // Create Admin User
+        User admin = new User();
+        admin.setUserName("adminUser");
+        admin.setPassword(passwordEncoder.encode("password"));
+        admin.setRole("ROLE_ADMIN");
+        userRepository.save(admin);
+
+        this.validAdminToken = jwtTokenProvider.generateToken(admin.getUserName(), admin.getRole());
+
+        User normalUser = new User();
+        normalUser.setUserName("generalUser");
+        normalUser.setPassword(passwordEncoder.encode("password"));
+        normalUser.setRole("ROLE_USER");
+        userRepository.save(normalUser);
+
+        this.validUserToken = jwtTokenProvider.generateToken(normalUser.getUserName(), normalUser.getRole());
+    }
+
+    @Test
+    void testAccessWithValidUserToken() throws Exception {
+        // Normal user should be able to access GET /api/products
+        mockMvc.perform(get("/api/products")
+                .header("Authorization", "Bearer " + validUserToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testAccessWithValidAdminToken() throws Exception {
+        // Admin user should be able to access GET /api/products
+        mockMvc.perform(get("/api/products")
+                .header("Authorization", "Bearer " + validAdminToken))
+                .andExpect(status().isOk());
+    }
+
+
+    @Test
+    void testInvalidTokenErrorHandling() throws Exception {
+        String invalidToken = "invalid.token.string.here";
+
+        // Accessing with invalid token -> Expected 401 Unauthorized
+        mockMvc.perform(get("/api/products")
+                .header("Authorization", "Bearer " + invalidToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("認証エラー"));
+    }
+
+    @Test
+    void testExpiredTokenErrorHandling() throws Exception {
+        // Intentionally create an expired token
+        SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+        
+        String expiredToken = Jwts.builder()
+                .subject("user@example.com")
+                .claim("role", "ROLE_USER")
+                .issuedAt(new Date(System.currentTimeMillis() - 1000 * 60 * 60 * 24)) // Issued 1 day ago
+                .expiration(new Date(System.currentTimeMillis() - 1000 * 60)) // Expired 1 min ago
+                .signWith(key)
+                .compact();
+
+        // Accessing with expired token -> Expected 401 Unauthorized
+        mockMvc.perform(get("/api/products")
+                .header("Authorization", "Bearer " + expiredToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("認証エラー"))
+                .andExpect(jsonPath("$.message").value("有効期限が切れています。再度ログインしてください。"));
+    }
+}


### PR DESCRIPTION
## 📝 概要
- JWT認証時のエラーハンドリングを実装し、トークンの有効期限切れや不正なトークンに対して適切なエラーレスポンス（401）を返すようにした。

## 🔧 変更内容
- `JwtTokenProvider`: トークン検証時に `ExpiredJwtException` と `JwtException` を区別してキャッチし、それぞれ独自例外（`ExpiredTokenException` / `InvalidTokenException`）をスローするように変更
- `JwtAuthenticationFilter`: フィルター内で発生した例外を `HandlerExceptionResolver` 経由で [GlobalExceptionHandler]に委譲するように変更
- [GlobalExceptionHandler]: `ExpiredTokenException` と `InvalidTokenException` に対応する `@ExceptionHandler` を追加し、401ステータスと日本語エラーメッセージを返却
- `SecurityConfig`: `authenticationEntryPoint` の設定と、JWTフィルターを `UsernamePasswordAuthenticationFilter` の前に登録する設定を追加
- `ExpiredTokenException` / `InvalidTokenException`: 新規カスタム例外クラスを追加

## ✅ 確認内容
- 有効なユーザートークンでのAPIアクセスが正常に動作すること（200 OK）
- 有効な管理者トークンでのAPIアクセスが正常に動作すること（200 OK）
- 不正なトークンでのアクセス時に401と `{"error":"認証エラー"}` が返却されること
- 有効期限切れトークンでのアクセス時に401と `{"error":"認証エラー","message":"有効期限が切れています。再度ログインしてください。"}` が返却されること
- 上記をカバーするJUnitテスト（`JwtSecurityTest`）を新規追加し、全件パスを確認済み

## 📸 スクリーンショット
- UI変更なし（バックエンドAPIのみの変更）


